### PR TITLE
Adding report generation dependencies to Dockerfile

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,13 +16,13 @@ jobs:
       matrix:
         package:
           - name: aragog
-            pkg_root: ./tests/packages/aragog
-            template_path: ./template.Rmd
-            report_format: pdf
+            report_pkg_dir: ./tests/packages/aragog
+            report_template_path: ./template.Rmd
+            report_format: pdf_document
           - name: buckbeak
-            pkg_root: ./tests/packages/buckbeak
-            template_path: ./tests/packages/buckbeak/validation-template.Rmd
-            report_format: html
+            report_pkg_dir: ./tests/packages/buckbeak
+            report_template_path: ./tests/packages/buckbeak/validation-template.Rmd
+            report_format: html_document
 
 
     steps:
@@ -32,8 +32,8 @@ jobs:
       - name: Generate validation report for ${{ matrix.package.name }}
         uses: ./
         with:
-          pkg_root: ${{ matrix.package.pkg_root }}
-          template_path: ${{ matrix.package.template_path }}
+          report_pkg_dir: ${{ matrix.package.report_pkg_dir }}
+          report_template_path: ${{ matrix.package.report_template_path }}
           report_format: ${{ matrix.package.report_format }}
 
       - name: Upload ${{ matrix.package.name }} validation report
@@ -41,5 +41,5 @@ jobs:
         if: success()
         with:
           name: ${{ matrix.package.name }} validation report
-          path: ${{ matrix.package.pkg_root }}/validation-report.${{ matrix.package.report_format }}
+          path: validation-report.*
           if-no-files-found: error

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,11 +18,11 @@ jobs:
           - name: aragog
             report_pkg_dir: ./tests/packages/aragog
             report_template_path: ./template.Rmd
-            report_format: pdf_document
+            report_rmarkdown_format: pdf_document
           - name: buckbeak
             report_pkg_dir: ./tests/packages/buckbeak
             report_template_path: ./tests/packages/buckbeak/validation-template.Rmd
-            report_format: html_document
+            report_rmarkdown_format: html_document
 
 
     steps:
@@ -34,7 +34,7 @@ jobs:
         with:
           report_pkg_dir: ${{ matrix.package.report_pkg_dir }}
           report_template_path: ${{ matrix.package.report_template_path }}
-          report_format: ${{ matrix.package.report_format }}
+          report_rmarkdown_format: ${{ matrix.package.report_rmarkdown_format }}
 
       - name: Upload ${{ matrix.package.name }} validation report
         uses: actions/upload-artifact@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,5 +41,5 @@ jobs:
         if: success()
         with:
           name: ${{ matrix.package.name }} validation report
-          path: validation-report.*
+          path: validation_report.*
           if-no-files-found: error

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM docker.io/rocker/verse:4.1.0
 
 # requires dev version of covr (>= 3.5.1.9003)
+# also install package dependencies (for tests)
 RUN R -e "remotes::install_github('r-lib/covr')" \
-      -e "remotes::install_github('genentech/covtracer')"
+      -e "remotes::install_github('genentech/covtracer')" 
 
 # Copy validator and template
 COPY report-generator.R /main.R

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM docker.io/rocker/verse:4.1.0
 
 # requires dev version of covr (>= 3.5.1.9003)
-RUN R -e "remotes::install_github('r-lib/covr')"
-RUN R -e "remotes::install_github('genentech/covtracer')"
+RUN R -e "remotes::install_github('r-lib/covr')" \
+      -e "remotes::install_github('genentech/covtracer')"
 
 # Copy validator and template
 COPY report-generator.R /main.R

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM rocker/verse:4.1.0
+FROM docker.io/rocker/verse:4.1.0
+
+# requires dev version of covr (>= 3.5.1.9003)
+RUN R -e "remotes::install_github('r-lib/covr')"
+RUN R -e "remotes::install_github('genentech/covtracer')"
 
 # Copy validator and template
 COPY report-generator.R /main.R

--- a/action.yml
+++ b/action.yml
@@ -3,22 +3,22 @@ author: Roche
 description: A Github Action that generates a validation report for an R package.
 
 inputs:
-  pkg_root:
+  report_pkg_dir:
     description: Path to package's root.
     required: false
     default: "."
-  template_path:
+  report_template_path:
     description: |
       File path of the R markdown template to use for the report.
       The default template is available [here.](./template.Rmd)
     required: false
     default: "template.Rmd"
-  report_format:
+  report_rmarkdown_format:
     description: |
-      The file format of the validation report.
-      Options: `pdf`, `html`, `word`, `odt`, `markdown`
+      The file format of the validation report. See `rmarkdown::render`'s
+      `output_format` parameter for accepted values.
     required: false
-    default: pdf
+    default: "all"
 
 # Run as a Docker action
 runs:
@@ -26,5 +26,5 @@ runs:
   image: './Dockerfile'
 
 branding: # https://feathericons.com/
-  icon: 'award'  
+  icon: 'award'
   color: 'blue'

--- a/report-generator.R
+++ b/report-generator.R
@@ -19,6 +19,9 @@ if (!file.exists(file.path(pkg_dir, "DESCRIPTION"))) {
   ))
 }
 
+# Install package dependencies
+devtools::install_dev_deps(pkg_dir)
+
 # allow rmarkdown to choose appropriate file extension for output format
 report_file_path <- rmarkdown::render(
   template_path,

--- a/report-generator.R
+++ b/report-generator.R
@@ -23,7 +23,7 @@ if (!file.exists(file.path(pkg_dir, "DESCRIPTION"))) {
 report_file_path <- rmarkdown::render(
   template_path,
   output_dir = getwd(),  # create report wherever R script was called 
-  output_file = "validation_report"
+  output_file = "validation_report",
   output_format = report_format,
   params = list(pkg_dir = pkg_dir)
 )

--- a/report-generator.R
+++ b/report-generator.R
@@ -1,17 +1,37 @@
 #!/usr/bin/env Rscript
 
 # Get the action inputs from preset env vars
-pkg_root <- Sys.getenv("INPUT_PKG_ROOT")
-template_path <- Sys.getenv("INPUT_TEMPLATE_PATH")
-report_type <- Sys.getenv("INPUT_REPORT_FORMAT")
+pkg_dir <- Sys.getenv("INPUT_REPORT_PKG_DIR", ".")
+template_path <- Sys.getenv("INPUT_REPORT_TEMPLATE_PATH", "template.Rmd")
+report_format <- Sys.getenv("INPUT_REPORT_RMARKDOWN_FORMAT", "all")
 
-# Navigate to package root
-setwd(pkg_root)
+# fail with meaningful message if REPORT_PKG_DIR does not appear to be a package
+if (!file.exists(file.path(pkg_dir, "DESCRIPTION"))) {
+  stop(sprintf(
+    paste(sep = "\n",
+      "Could not find package at '%s'",
+      "    ",
+      "    Specify a directory by definining environment variable:",
+      "        REPORT_PKG_DIR=<repository subdirectory>",
+      "    "
+    ),
+    pkg_dir
+  ))
+}
 
-# Set report file path
-report_file_path <- file.path(getwd(), paste0("validation-report.", report_type))
+# allow rmarkdown to choose appropriate file extension for output format
+rendered_report <- rmarkdown::render(
+  template_path,
+  output_format = report_format,
+  params = list(pkg_dir = pkg_dir)
+)
 
-# TODO: Implement additional logic
+# create a new file path, using extension preferred by report_format
+report_ext <- gsub("^[^.]*", "", basename(rendered_report))  # for multi-part exts
+report_file_path <- normalizePath(mustWork = FALSE, file.path(
+  gsub("/+$", "", dirname(rendered_report)),
+  paste0("validation_report", report_ext)
+))
 
-# Placeholder till TODO above is complete
-if (file.create(report_file_path)) cat(paste0("Created report at: ", report_file_path))
+file.rename(rendered_report, report_file_path)
+cat(sprintf("Created report at: '%s'", report_file_path))

--- a/report-generator.R
+++ b/report-generator.R
@@ -20,18 +20,12 @@ if (!file.exists(file.path(pkg_dir, "DESCRIPTION"))) {
 }
 
 # allow rmarkdown to choose appropriate file extension for output format
-rendered_report <- rmarkdown::render(
+report_file_path <- rmarkdown::render(
   template_path,
+  output_dir = getwd(),  # create report wherever R script was called 
+  output_file = "validation_report"
   output_format = report_format,
   params = list(pkg_dir = pkg_dir)
 )
 
-# create a new file path, using extension preferred by report_format
-report_ext <- gsub("^[^.]*", "", basename(rendered_report))  # for multi-part exts
-report_file_path <- normalizePath(mustWork = FALSE, file.path(
-  gsub("/+$", "", dirname(rendered_report)),
-  paste0("validation_report", report_ext)
-))
-
-file.rename(rendered_report, report_file_path)
 cat(sprintf("Created report at: '%s'", report_file_path))

--- a/template.Rmd
+++ b/template.Rmd
@@ -1,6 +1,8 @@
 ---
 title: "Validation Report"
 subtitle: "`r sprintf('%s (v%s)', (dcf <- read.dcf(file.path(params$pkg_dir, 'DESCRIPTION')))[,'Package'], dcf[,'Version'])`"
+output:
+  - "md_document"
 params:
   pkg_dir: "."
 ---
@@ -44,13 +46,22 @@ kable(data.frame(
 ## Version Control
 
 ```{r version_control, echo = FALSE}
-# assumes working dir is target repo or $GIT_DIR and $GIT_WORK_TREE are set 
+# find .git dir containing the package directory
+gd <- system(
+  sprintf("cd '%s' && git rev-parse --absolute-git-dir", params$pkg_dir),
+  intern = TRUE
+)
+
+# define reused git args to be sure we're picking up the right git info
+gd <- sprintf("--git-dir='%s'", gd)
+wt <- sprintf("--work-tree='%s'", params$pkg_dir)
+
 kable(data.frame(
   Field = c("branch", "commit `SHA1`", "commit date"),
   Value = c(
-    system2("git", list("rev-parse", "--abbrev-ref", "HEAD"), stdout = TRUE),
-    system2("git", list("rev-parse", "HEAD"), stdout = TRUE),
-    system2("git", list("show", "-s", "--format=%ci", "HEAD"), stdout = TRUE)
+    system2("git", list(gd, wt, "rev-parse", "--abbrev-ref", "HEAD"), stdout = TRUE),
+    system2("git", list(gd, wt, "rev-parse", "HEAD"), stdout = TRUE),
+    system2("git", list(gd, wt, "show", "-s", "--format=%ci", "HEAD"), stdout = TRUE)
   )))
 ```
 

--- a/template.Rmd
+++ b/template.Rmd
@@ -8,17 +8,13 @@ params:
 ---
 
 ```{r, include = FALSE}
-options(
-  width = 80L,
-  covr.record_tests = TRUE,
-  keep.source = TRUE,
-  keep.source.pkg = TRUE
-)
+options(width = 80L, covr.record_tests = TRUE)
 
 remotes::install_local(
   params$pkg_dir,
   force = TRUE,
-  quiet = TRUE
+  quiet = TRUE,
+  INSTALL_opts = "--with-keep.source"
 )
 
 library(knitr)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Please describe your pull request -->

First, I didn't have the good sense to look at ongoing work before kicking this off, so some of it is a bit overlapping with @epijim's `add/generator` branch.

# Changes

- Added `docker.io/` prefix to `FROM` statement (thanks `podman` for warning me that omitting this is a potential security concern... also means the same file should work without issue now on `podman` as well as `docker` without additional configurations)
- Added `remotes::install_github` steps to the Dockerfile to install `covtracer` from github
- Incorporated `params$pkg_dir` when collecting `git` info in the template report
- Generalized the report format to accept any valid render target for `rmarkdown::render` - defaults to "all" (which uses the output defined in the template, `"md_document"`). Instead of accepting an extension, this should now accept render formats - eg "pdf_document" instead of "pdf".
- Renamed inputs to have a `report_` prefix. Not sure how inputs get managed across multiple actions, but I felt that having a prefix might help mitigate potential input name conflicts. Feel free to revert this change if that's not necessary. 

# Considerations

I'm not totally comfortable with what directory structure we should assume gets mounted into the action container. I tested it assuming the repo contents get copied into the container's $HOME (/root). Nothing is hard coded around this assumption, but it hasn't been tested against anything else. 
