### PR TITLE
Revert to using verse, but 4.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,4 @@
-FROM docker.io/rocker/tidyverse:4.1.1
-
-# Add missing library to fix "unable to load shared object '/usr/local/lib/R/modules//R_X11.so'"
-RUN apt-get update && apt-get install -y \
-      libxt6 \
-       && rm -rf /var/lib/apt/lists/*
+FROM docker.io/rocker/verse:4.1.1
 
 # Copy validator and template
 COPY report-generator.R /main.R

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
       File path of the R markdown template to use for the report.
       The default template is available [here.](./template.Rmd)
     required: false
-    default: "template.Rmd"
+    default: "/template.Rmd"
   report_rmarkdown_format:
     description: |
       The file format of the validation report. See `rmarkdown::render`'s

--- a/dependencies.R
+++ b/dependencies.R
@@ -10,7 +10,5 @@ github_packages <- c(
 )
 lapply(github_packages, remotes::install_github)
 
-# Install TinyTex globally
-tinytex::install_tinytex()
-system("mv $HOME/bin/* /usr/local/bin")
+# Install missing fonts
 system("tlmgr install courier ec")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Please describe your pull request -->
Also change the default location of `template.Rmd` so it can be found during the CI run.