### PR TITLE
Disabling report rendering during R CMD check

### DIFF
--- a/template.Rmd
+++ b/template.Rmd
@@ -98,7 +98,16 @@ params$pkg_dir %>%
 ## `R CMD check`
 
 ```{r r_cmd_check, echo = FALSE, eval = TRUE}
-rcmdcheck_results <- rcmdcheck::rcmdcheck(params$pkg_dir, quiet = TRUE)
+rcmdcheck_results <- rcmdcheck::rcmdcheck(
+  params$pkg_dir,
+  args = c(
+    "--timings",             # include execution times in output
+    "--no-build-vignettes",  # run vignette code, but disable pdf rendering
+    "--no-manual"            # disable pdf manual rendering
+  ),
+  quiet = TRUE
+)
+
 cat(rcmdcheck_results$stdout)
 cat(rcmdcheck_results$stderr)
 ```


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Please describe your pull request -->

These flags will still run the code in the vignettes, but will disable rendering to pdf for both the vignettes and the documentation manual, mitigating system-dependent issues based on installed latex dependencies.