### PR TITLE
Disable auto-upgrades of packages

### DIFF
--- a/template.Rmd
+++ b/template.Rmd
@@ -28,7 +28,8 @@ remotes::install_local(
   params$pkg_dir,
   force = TRUE,
   quiet = TRUE,
-  INSTALL_opts = "--with-keep.source"
+  INSTALL_opts = "--with-keep.source",
+  upgrade = "never"
 )
 library(magrittr)
 library(knitr)


### PR DESCRIPTION
To make sure that we are not upgrading dependencies when install the R package itself.

