### PR TITLE
fix: change theme to default

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,9 +22,11 @@ jobs:
           - name: aragog
             report_pkg_dir: ./tests/packages/aragog
             report_template_path: ./template.qmd
+            report_path: ./validation_report.pdf
           - name: buckbeak
             report_pkg_dir: ./tests/packages/buckbeak
             report_template_path: ./tests/packages/buckbeak/validation-template.qmd
+            report_path: ./tests/packages/buckbeak/validation_report.pdf
 
     steps:
       - name: Checkout ${{ matrix.package.name }}
@@ -37,13 +39,10 @@ jobs:
           report_pkg_dir: ${{ matrix.package.report_pkg_dir }}
           report_template_path: ${{ matrix.package.report_template_path }}
 
-      - name: Debug
-        run: ls -lR ./tests/packages/
-
       - name: Upload ${{ matrix.package.name }} validation report
         uses: actions/upload-artifact@v4
         if: success()
         with:
           name: ${{ matrix.package.name }} validation report
-          path: validation_report.pdf
+          path: ${{ matrix.package.report_path }}
           if-no-files-found: error

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,9 @@ jobs:
           report_pkg_dir: ${{ matrix.package.report_pkg_dir }}
           report_template_path: ${{ matrix.package.report_template_path }}
 
+      - name: Debug
+        run: ls -lR ./tests/packages/
+
       - name: Upload ${{ matrix.package.name }} validation report
         uses: actions/upload-artifact@v4
         if: success()

--- a/.github/workflows/test_no_cache.yaml
+++ b/.github/workflows/test_no_cache.yaml
@@ -22,6 +22,7 @@ jobs:
           - name: buckbeak
             report_pkg_dir: ./tests/packages/buckbeak
             report_template_path: ./tests/packages/buckbeak/validation-template.qmd
+            report_path: ./tests/packages/buckbeak/validation_report.pdf
 
     steps:
       - name: Checkout ${{ matrix.package.name }}
@@ -35,13 +36,10 @@ jobs:
           report_template_path: ${{ matrix.package.report_template_path }}
           no_cache: true
 
-      - name: Debug
-        run: ls -lR ./tests/packages/
-
       - name: Upload ${{ matrix.package.name }} validation report
         uses: actions/upload-artifact@v4
         if: success()
         with:
           name: ${{ matrix.package.name }} validation report
-          path: validation_report.pdf
+          path: ${{ matrix.package.report_path }}
           if-no-files-found: error

--- a/.github/workflows/test_no_cache.yaml
+++ b/.github/workflows/test_no_cache.yaml
@@ -35,6 +35,9 @@ jobs:
           report_template_path: ${{ matrix.package.report_template_path }}
           no_cache: true
 
+      - name: Debug
+        run: ls -lR ./tests/packages/
+
       - name: Upload ${{ matrix.package.name }} validation report
         uses: actions/upload-artifact@v4
         if: success()

--- a/template.qmd
+++ b/template.qmd
@@ -55,7 +55,7 @@ tt_sys_info_df <- data.frame(
 tt(
   tt_sys_info_df,
   caption = "System information",
-  theme = "bootstrap"
+  theme = "default"
 )
 ```
 
@@ -93,7 +93,7 @@ tt_git_df <- data.frame(
 tt(
   tt_git_df,
   caption = "Git information",
-  theme = "bootstrap"
+  theme = "default"
 )
 ```
 
@@ -135,7 +135,7 @@ tt_riskmetric_df <- d_riskmetric %>%
 tt(
   tt_riskmetric_df,
   caption = "Package info assessed by the R package riskmetric",
-  theme = "bootstrap"
+  theme = "default"
 )
 ```
 
@@ -209,7 +209,7 @@ if (require("covtracer", quietly = TRUE)) {
     tt(
       tt_covtracer_df,
       caption = "Tracebility matrix mapping unit tests to documented behaviours.",
-      theme = "bootstrap"
+      theme = "default"
     )
   } else {
     cat("No test suites.")
@@ -238,7 +238,7 @@ if (require("covtracer", quietly = TRUE)) {
     tt(
       tt_untested_df,
       caption = "Untested behaviours: documentation that is not covered by any test.",
-      theme = "bootstrap"
+      theme = "default"
     )
   }
 } else {
@@ -263,7 +263,7 @@ if (require("covtracer", quietly = TRUE)) {
   tt(
     tt_granularity_df,
     caption = "Granularity of unit tests: directly tested exported functions.",
-    theme = "bootstrap"
+    theme = "default"
   )
 } else {
   cat("{covtracer} not available to produce a traceability matrix")


### PR DESCRIPTION
Closes https://github.com/insightsengineering/thevalidatoR/issues/84.

According to https://github.com/insightsengineering/thevalidatoR/issues/84, `bootstrap` theme seems not to be supported by `tinytable` anymore. `default` theme has been selected as replacement (I would suggest setting a 'lightweight' theme due to previous performance issues with a 'heavier' theme: https://github.com/insightsengineering/thevalidatoR/pull/76).

I checked that very long tables are rendered correctly:
* [`formatters`](https://github.com/walkowif/formatters/actions/runs/17736518580/job/50399603509)
<img width="550"  alt="image" src="https://github.com/user-attachments/assets/7dd8c911-ce43-49f5-9715-30b079efb610" />

* [`tern`](https://github.com/walkowif/tern/actions/runs/17736496172/job/50399529387)
<img width="550" alt="image" src="https://github.com/user-attachments/assets/a17943b9-eb6e-406d-8320-75297bb14b05" />

